### PR TITLE
"SyntaxError: malformed formal parameter" with leading spaces in expression

### DIFF
--- a/to-function.js
+++ b/to-function.js
@@ -75,7 +75,7 @@ String.prototype.lambda = function() {
     if (sections.length > 1) {
         while (sections.length) {
             expr = sections.pop();
-            params = sections.pop().split(/\s*,\s*|\s+/m);
+            params = sections.pop().replace(/^\s*(.*)\s*$/, '$1').split(/\s*,\s*|\s+/m);
             sections.length && sections.push('(function('+params+'){return ('+expr+')})');
         }
     } else if (expr.match(/\b_\b/)) {


### PR DESCRIPTION
If an expresson has leading spaces, like in "     x->x*2".lambda(), Firefox bails out with "SyntaxError: malformed formal parameter". Trimming the expression solves this issue. The tests reports "passed". I assume, that even the crappy browsers support the use of numbered captering groups in regex.
